### PR TITLE
Fix menu bar quick note popover

### DIFF
--- a/MenuBarNotes/ContentView.swift
+++ b/MenuBarNotes/ContentView.swift
@@ -17,9 +17,22 @@ struct ContentView: View {
             List {
                 ForEach(items) { item in
                     NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
+                        VStack(alignment: .leading) {
+                            Text(item.text)
+                                .font(.body)
+                            Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding()
                     } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+                        VStack(alignment: .leading) {
+                            Text(item.text)
+                                .lineLimit(1)
+                            Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
                     }
                 }
                 .onDelete(perform: deleteItems)
@@ -27,7 +40,7 @@ struct ContentView: View {
             .navigationSplitViewColumnWidth(min: 180, ideal: 200)
             .toolbar {
                 ToolbarItem {
-                    Button(action: addItem) {
+                    Button(action: { addItem() }) {
                         Label("Add Item", systemImage: "plus")
                     }
                 }
@@ -37,9 +50,9 @@ struct ContentView: View {
         }
     }
 
-    private func addItem() {
+    private func addItem(text: String = "New Note") {
         withAnimation {
-            let newItem = Item(timestamp: Date())
+            let newItem = Item(timestamp: Date(), text: text)
             modelContext.insert(newItem)
         }
     }

--- a/MenuBarNotes/Item.swift
+++ b/MenuBarNotes/Item.swift
@@ -11,8 +11,10 @@ import SwiftData
 @Model
 final class Item {
     var timestamp: Date
-    
-    init(timestamp: Date) {
+    var text: String
+
+    init(timestamp: Date, text: String) {
         self.timestamp = timestamp
+        self.text = text
     }
 }

--- a/MenuBarNotes/MenuBarNotesApp.swift
+++ b/MenuBarNotes/MenuBarNotesApp.swift
@@ -28,5 +28,11 @@ struct MenuBarNotesApp: App {
             ContentView()
         }
         .modelContainer(sharedModelContainer)
+
+        MenuBarExtra("Quick Note", systemImage: "square.and.pencil") {
+            QuickNotePopover()
+        }
+        .menuBarExtraStyle(.window)
+        .modelContainer(sharedModelContainer)
     }
 }

--- a/MenuBarNotes/QuickNotePopover.swift
+++ b/MenuBarNotes/QuickNotePopover.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import SwiftData
+
+struct QuickNotePopover: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var text: String = ""
+    var onClose: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .trailing) {
+            TextEditor(text: $text)
+                .frame(minWidth: 200, minHeight: 120)
+                .padding(.bottom, 4)
+
+            HStack {
+                Spacer()
+                Button("Save") { save() }
+                    .keyboardShortcut(.return, modifiers: [.command])
+            }
+        }
+        .padding()
+    }
+
+    private func save() {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let item = Item(timestamp: Date(), text: trimmed)
+        modelContext.insert(item)
+        text = ""
+        onClose?()
+    }
+}
+
+#Preview {
+    QuickNotePopover()
+        .modelContainer(for: Item.self, inMemory: true)
+}
+


### PR DESCRIPTION
## Summary
- add `text` field to `Item` model
- show saved text in `ContentView`
- create `QuickNotePopover` view with a Command+Enter shortcut to save
- add a menu bar extra that displays the quick note popover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68489f664db8832ca7d1bac70685d507