### PR TITLE
Menu bar only mode with popover

### DIFF
--- a/MenuBarNotes/AppNotifications.swift
+++ b/MenuBarNotes/AppNotifications.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Notification.Name {
+    static let openMainWindow = Notification.Name("OpenMainWindow")
+}

--- a/MenuBarNotes/MenuBarNotesApp.swift
+++ b/MenuBarNotes/MenuBarNotesApp.swift
@@ -11,7 +11,7 @@ import AppKit
 
 @main
 struct MenuBarNotesApp: App {
-    @Environment(\.openWindow) private var openWindow
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
@@ -26,30 +26,13 @@ struct MenuBarNotesApp: App {
         }
     }()
 
-    var body: some Scene {
-        WindowGroup(id: "MainWindow") {
-            ContentView()
-        }
-        .modelContainer(sharedModelContainer)
+    init() {
+        appDelegate.container = sharedModelContainer
+    }
 
+    var body: some Scene {
         Settings {
             PreferencesView()
         }
-
-        MenuBarExtra("Quick Note", systemImage: "square.and.pencil") {
-            QuickNotePopover()
-        } menu: {
-            Button("Open Notes") { openWindow(id: "MainWindow") }
-            Button("Preferences\u2026") {
-                if NSApp.responds(to: #selector(NSApplication.showPreferencesWindow)) {
-                    NSApp.sendAction(#selector(NSApplication.showPreferencesWindow), to: nil, from: nil)
-                }
-            }
-            Divider()
-            Button("Quit") { NSApp.terminate(nil) }
-
-        }
-        .menuBarExtraStyle(.window)
-        .modelContainer(sharedModelContainer)
     }
 }

--- a/MenuBarNotes/QuickNotePopover.swift
+++ b/MenuBarNotes/QuickNotePopover.swift
@@ -13,6 +13,7 @@ struct QuickNotePopover: View {
                 .padding(.bottom, 4)
 
             HStack {
+                Button("Open App") { openApp() }
                 Spacer()
                 Button("Save") { save() }
                     .keyboardShortcut(.return, modifiers: [.command])
@@ -30,6 +31,11 @@ struct QuickNotePopover: View {
         text = ""
         dismiss()
 
+    }
+
+    private func openApp() {
+        NotificationCenter.default.post(name: .openMainWindow, object: nil)
+        dismiss()
     }
 }
 


### PR DESCRIPTION
## Summary
- add notification name for activating main window
- provide AppDelegate handling menu bar behavior and popover toggling
- update popover with `Open App` button to trigger main window
- run app as background agent via `NSApp.setActivationPolicy`

## Testing
- `swift test` *(fails: "Could not find Package.swift" because this is an Xcode project)*

------
https://chatgpt.com/codex/tasks/task_e_6850185fe354832cb09e6955c7f23ae1