### PR TITLE
Implement main window delegate cleanup

### DIFF
--- a/MenuBarNotes/AppDelegate.swift
+++ b/MenuBarNotes/AppDelegate.swift
@@ -2,7 +2,7 @@ import Cocoa
 import SwiftData
 import SwiftUI
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var statusItem: NSStatusItem!
     var popover: NSPopover?
     var mainWindow: NSWindow?
@@ -86,11 +86,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let window = NSWindow(contentViewController: hosting)
             window.title = "Notes"
             window.setContentSize(NSSize(width: 480, height: 320))
+            window.delegate = self
             mainWindow = window
         }
         NSApp.setActivationPolicy(.regular)
         mainWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        mainWindow = nil
+        NSApp.setActivationPolicy(.accessory)
     }
 }
 


### PR DESCRIPTION
## Summary
- adopt `NSWindowDelegate` in `AppDelegate`
- set the delegate when constructing `mainWindow`
- clean up on window close and reset activation policy

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68501d00a344832c81ec3cf837dd9a56