### PR TITLE
Add README with Xcode build and test notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# MenuBarNotes
+
+MenuBarNotes is a macOS menu bar utility for quickly keeping notes. It is delivered as a standard Xcode project rather than a Swift package.
+
+## Building
+
+1. Open `MenuBarNotes.xcodeproj` in **Xcode**.
+2. Select the desired scheme and build the app with **Product ▸ Build** or the <kbd>⌘B</kbd> shortcut.
+
+## Running Tests
+
+Unit and UI tests must be run from Xcode. Open the workspace created by Xcode when building the project, then run the tests via **Product ▸ Test** (<kbd>⌘U</kbd>).
+
+Running `swift test` in the repository root will fail because this project is not a Swift Package.


### PR DESCRIPTION
## Summary
- document the MenuBarNotes project
- explain how to build with Xcode
- provide notes about running tests via Xcode workspace
- call out that `swift test` will fail because there is no Swift Package

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68501d020f48832ca68be71cf01727d7